### PR TITLE
added middleware to reduce var instantiation redundancy

### DIFF
--- a/routes/campaignsRoute.js
+++ b/routes/campaignsRoute.js
@@ -2,24 +2,28 @@
 // import dependencies
 var router = require('express').Router();
 
+// mongoose vars
+var mongoose,
+	campaignsSchema;
+
 // route http reqs
-router.route('/')
-	.delete(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed DELETE req');
+router.use(function(req, res, next) {
+		mongoose = req.app.get('mongoose');
+		next();
 	})
-	.get(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed GET req');
-	})
-	.post(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed POST req');
-	})
-	.put(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed PUT req');
-	});
+	.route('/')
+		.delete(function(req, res) {
+			res.send('Accessed DELETE req');
+		})
+		.get(function(req, res) {
+			res.send('Accessed GET req');
+		})
+		.post(function(req, res) {
+			res.send('Accessed POST req');
+		})
+		.put(function(req, res) {
+			res.send('Accessed PUT req');
+		});
 
 // make available to node app
 module.exports = router;

--- a/routes/encountersRoute.js
+++ b/routes/encountersRoute.js
@@ -2,24 +2,28 @@
 // import dependencies
 var router = require('express').Router();
 
+// mongoose vars
+var mongoose,
+	encountersSchema;
+
 // route http reqs
-router.route('/')
-	.delete(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed DELETE req');
+router.use(function(req, res, next) {
+		mongoose = req.app.get('mongoose');
+		next();
 	})
-	.get(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed GET req');
-	})
-	.post(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed POST req');
-	})
-	.put(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed PUT req');
-	});
+	.route('/')
+		.delete(function(req, res) {
+			res.send('Accessed DELETE req');
+		})
+		.get(function(req, res) {
+			res.send('Accessed GET req');
+		})
+		.post(function(req, res) {
+			res.send('Accessed POST req');
+		})
+		.put(function(req, res) {
+			res.send('Accessed PUT req');
+		});
 
 // make available to node app
 module.exports = router;

--- a/routes/monstersRoute.js
+++ b/routes/monstersRoute.js
@@ -2,24 +2,28 @@
 // import dependencies
 var router = require('express').Router();
 
+// mongoose vars
+var mongoose,
+	monstersSchema;
+
 // route http reqs
-router.route('/')
-	.delete(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed DELETE req');
+router.use(function(req, res, next) {
+		mongoose = req.app.get('mongoose');
+		next();
 	})
-	.get(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed GET req');
-	})
-	.post(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed POST req');
-	})
-	.put(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed PUT req');
-	});
+	.route('/')
+		.delete(function(req, res) {
+			res.send('Accessed DELETE req');
+		})
+		.get(function(req, res) {
+			res.send('Accessed GET req');
+		})
+		.post(function(req, res) {
+			res.send('Accessed POST req');
+		})
+		.put(function(req, res) {
+			res.send('Accessed PUT req');
+		});
 
 // make available to node app
 module.exports = router;

--- a/routes/monsters_encountersRoute.js
+++ b/routes/monsters_encountersRoute.js
@@ -2,24 +2,28 @@
 // import dependencies
 var router = require('express').Router();
 
+// mongoose vars
+var mongoose,
+	monsters_encountersSchema;
+
 // route http reqs
-router.route('/')
-	.delete(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed DELETE req');
+router.use(function(req, res, next) {
+		mongoose = req.app.get('mongoose');
+		next();
 	})
-	.get(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed GET req');
-	})
-	.post(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed POST req');
-	})
-	.put(function(req, res) {
-		var mongoose = req.app.get('mongoose');
-		res.send('Accessed PUT req');
-	});
+	.route('/')
+		.delete(function(req, res) {
+			res.send('Accessed DELETE req');
+		})
+		.get(function(req, res) {
+			res.send('Accessed GET req');
+		})
+		.post(function(req, res) {
+			res.send('Accessed POST req');
+		})
+		.put(function(req, res) {
+			res.send('Accessed PUT req');
+		});
 
 // make available to node app
 module.exports = router;


### PR DESCRIPTION
<code>var mongoose = req.app.get('mongoose');</code> was used in all http requests. So I created a middleware function and moved the variable instantiation inside that. Now, it's only declared in one place.
